### PR TITLE
:bookmark: 3.19

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sphinxcontrib-moderncmakedomain
-version = 3.17
+version = 3.19
 long_description_content_type = text/markdown
 long_description= file: README.md
 author_email =


### PR DESCRIPTION
Copied files from https://gitlab.kitware.com/cmake/cmake/-/tree/v3.19.3/Utilities/Sphinx

@slurps-mad-rips if this MR is fine, could you please also release this version on Pip?

This fixes the warning:
RemovedInSphinx40Warning: The alias 'sphinx.util.pycompat.htmlescape' is deprecated, use 'html.escape' instead. Check CHANGES for Sphinx API modifications.

RemovedInSphinx40Warning: The alias 'sphinx.builders.qthelp.QtHelpBuilder' is deprecated, use 'sphinxcontrib.qthelp.QtHelpBuilder' instead. Check CHANGES for Sphinx API modifications.
  from .cmake import setup

Which was fixed in CMake repo with this MR:
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5326