### PR TITLE
feat: automate common tasks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 3.19.0
+
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
+
+[bumpversion:file:sphinxcontrib/moderncmakedomain/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+ci:
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+
+repos:
+- repo: https://github.com/asottile/setup-cfg-fmt
+  rev: v1.18.0
+  hooks:
+  - id: setup-cfg-fmt
+
+- repo: https://github.com/mgedmin/check-manifest
+  rev: "0.47"
+  hooks:
+  - id: check-manifest
+    stages: [manual]

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ $ pip install sphinxcontrib-moderncmakedomain
 
 Alternatively, place it inside of your `setup.py`, `pyproject.toml`,
 `requirements.txt` or whatever system it is that you use to declare and manage
-your dependencies. The version available will be in the same *major* version as
-the latest CMake release.
+your dependencies. A new version will only be released if there is a
+change to this extension inside CMake.
 
 ## Git
 
 This module is installable via `pip` and GitHub directly as well
 
 ```
-$ pip install git+https://github.com/slurps-mad-rips/moderncmakedomain.git
+$ pip install git+https://github.com/scikit-build/moderncmakedomain.git
 ```
 
 # Usage

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,51 @@
+import nox
+import urllib.request
+
+nox.options.sessions = ["lint"]
+
+
+@nox.session
+def lint(session: nox.Session) -> None:
+    """
+    Run the linter.
+    """
+    session.install("pre-commit")
+    session.run(
+        "pre-commit", "run", "--all-files", "--hook-stage=manual", *session.posargs
+    )
+
+
+@nox.session
+def build(session: nox.Session) -> None:
+    """
+    Build an SDist and wheel.
+    """
+
+    session.install("build")
+    session.run("python", "-m", "build")
+
+
+@nox.session
+def update(session: nox.Session) -> None:
+    """
+    Get the latest (or given) version of cmake and update the copy with it.
+    """
+
+    if session.posargs:
+        (version,) = session.posargs
+    else:
+        session.install("lastversion")
+        version = session.run(
+            "lastversion", "kitware/cmake", log=False, silent=True
+        ).strip()
+
+    cmake_url = f"https://raw.githubusercontent.com/Kitware/CMake/v{version}/Utilities/Sphinx/cmake.py"
+    colors_url = f"https://raw.githubusercontent.com/Kitware/CMake/v{version}/Utilities/Sphinx/colors.py"
+
+    urllib.request.urlretrieve(cmake_url, "sphinxcontrib/moderncmakedomain/cmake.py")
+    urllib.request.urlretrieve(colors_url, "sphinxcontrib/moderncmakedomain/colors.py")
+
+    session.install("bump2version")
+    session.run(
+        "bumpversion", "--allow-dirty", "--new-version", version, "patch", "setup.cfg"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.check-manifest]
+ignore = [
+    ".*",
+    "noxfile.py",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,30 +1,34 @@
 [metadata]
-name = sphinxcontrib-moderncmakedomain
-version = 3.19
+name = sphinxcontrib_moderncmakedomain
+version = 3.19.0
+description = Sphinx Domain for Modern CMake
+long_description = file: README.md
 long_description_content_type = text/markdown
-long_description= file: README.md
-author_email =
+url = https://github.com/scikit-build/moderncmakedomain
 author = Kitware
-maintainer_email =
 maintainer = Isabella Muerte
 license = BSD-3-Clause
+license_file = LICENSE.md
 platforms = any
-url = https://github.com/slurps-mad-rips/moderncmakedomain
-description = Sphinx Domain for Modern CMake
-keywords = sphinxcontrib, documentation, kitware, sphinx, cmake
 classifiers =
-  Intended Audience :: Developers
-  Environment :: Console
-  Environment :: Web Environment
-  License :: OSI Approved :: BSD License
-  Operating System :: OS Independent
-  Programming Language :: Python :: 3.5
-  Programming Language :: Python :: 3.6
-  Programming Language :: Python :: 3.7
-  Topic :: Documentation
-  Topic :: Utilities
+    Environment :: Console
+    Environment :: Web Environment
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Documentation
+    Topic :: Utilities
+keywords = sphinxcontrib, documentation, kitware, sphinx, cmake
 
 [options]
-zip_safe = False
-namespace_packages = sphinxcontrib
 packages = sphinxcontrib.moderncmakedomain
+python_requires = >=3.6
+namespace_packages = sphinxcontrib
+zip_safe = False

--- a/sphinxcontrib/moderncmakedomain/__init__.py
+++ b/sphinxcontrib/moderncmakedomain/__init__.py
@@ -1,3 +1,5 @@
 __import__('pkg_resources').declare_namespace(__name__)
 
 from .cmake import setup
+
+__version__ = "3.19.0"


### PR DESCRIPTION
Adding nox and some common task automation, and setup.cfg cleanup. Some remaining links fixed.

```bash
nox -s update
```

will get the latest version of CMake (selectable via `nox -s update -- X.Y.Z`), and update the code and versions.
