### PR TITLE
chore: Add Sphinx Extension classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ keywords = [
 classifiers = [
     "Environment :: Console",
     "Environment :: Web Environment",
+    "Framework :: Sphinx :: Extension",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).