### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: wntrblm/nox@2022.8.7
         with:
-          python-versions: "3.6, 3.7, 3.8, 3.9, 3.10, 3.11-dev"
+          python-versions: "3.7, 3.8, 3.9, 3.10, 3.11-dev"
       - run: nox -s tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 nox.options.sessions = ["lint", "tests"]
 
-ALL_PYTHONS = ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+ALL_PYTHONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 @nox.session
 def lint(session: nox.Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "sphinxcontrib-moderncmakedomain"
 description = "Sphinx Domain for Modern CMake"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 authors = [
     { name = "Kitware" },
 ]
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
I noticed there was a [workflow issue with Python 3.6](https://github.com/scikit-build/moderncmakedomain/actions/runs/3637887863/jobs/6139427288#step:3:32):
```
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
So instead of figure out how to fix it, I just removed support for Python 3.6 since it was EOL on 2021-12-23.