### PR TITLE
chore: cmake 3.26 update (parallel support)

### DIFF
--- a/sphinxcontrib/moderncmakedomain/__init__.py
+++ b/sphinxcontrib/moderncmakedomain/__init__.py
@@ -2,4 +2,4 @@ __import__('pkg_resources').declare_namespace(__name__)
 
 from .cmake import setup
 
-__version__ = "3.25.0"
+__version__ = "3.26.4"

--- a/sphinxcontrib/moderncmakedomain/cmake.py
+++ b/sphinxcontrib/moderncmakedomain/cmake.py
@@ -475,3 +475,4 @@ def setup(app):
     app.add_transform(CMakeTransform)
     app.add_transform(CMakeXRefTransform)
     app.add_domain(CMakeDomain)
+    return {"parallel_read_safe": True}


### PR DESCRIPTION
Updating to 3.26. See https://gitlab.kitware.com/cmake/cmake/-/issues/24934#note_1367903.
