### PR TITLE
Replace deprecated sphinx.testing.path with pathlib.Path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,6 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: ["--pytest-test-first"]
+        exclude: "^tests/roots"
       - id: requirements-txt-fixer
       - id: trailing-whitespace

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 
-from sphinx.testing.path import path
+from pathlib import Path
 
 pytest_plugins = 'sphinx.testing.fixtures'
 
 @pytest.fixture(scope="session")
 def rootdir():
-    return path(__file__).parent.abspath() / "roots"
+    return Path(__file__).parent.absolute() / "roots"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,6 +22,3 @@ def test_simple_html(app, status, warning, parallel):
     print(local)
     assert 'href="#variable:MYVAR"' in local
     assert 'id="variable:MYVAR"' in local
-
-
-


### PR DESCRIPTION
This PR gets rid of a deprecation warning with Sphinx 7