### PR TITLE
chore: restore manual pyproject format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,6 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.0.4"
-    hooks:
-      - id: pyproject-fmt
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-requires = [
-  "hatchling",
-]
 
 [project]
 name = "sphinxcontrib-moderncmakedomain"
@@ -34,27 +32,29 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Documentation",
   "Topic :: Utilities",
 ]
-dynamic = [
-  "version",
-]
+dynamic = ["version"]
 dependencies = [
   "sphinx>=2",
 ]
-optional-dependencies.test = [
+
+[project.optional-dependencies]
+test = [
   "defusedxml",
-  # Setuptools is required due to sphinx installing sphinxcontrib extensions that use pkg_resources (fixed upstream but not released yet)
   "pytest",
 ]
-urls.Homepage = "https://github.com/scikit-build/moderncmakedomain"
+
+[project.urls]
+Homepage = "https://github.com/scikit-build/moderncmakedomain"
+
 
 [tool.hatch]
 version.path = "sphinxcontrib/moderncmakedomain/__init__.py"
-build.targets.wheel.packages = [
-  "sphinxcontrib",
-]
+build.targets.wheel.packages = ["sphinxcontrib"]
+
 
 [tool.ruff]
 exclude = [
@@ -67,6 +67,7 @@ lint.extend-select = [
   "I",   # isort
   "UP",  # pyupgrade
 ]
+
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -82,6 +83,4 @@ filterwarnings = [
   "ignore::DeprecationWarning:sphinx.builders.gettext",
 ]
 log_cli_level = "info"
-testpaths = [
-  "tests",
-]
+testpaths = ["tests"]


### PR DESCRIPTION
I tried pyproject-fmt, but it is stripping the classifier I added when I added 3.13 testing (see https://github.com/tox-dev/toml-fmt/issues/6). That's not acceptable and I'm removing it. Also fixed the other changes I didn't like:

* Allow "magic comma", that is, single line lists if they don't have a trailing comma
* Allow `project.urls` and `project.optional-dependencies` to be grouped
* One space between related sections (`project.*`, `tool.X.*`), two between unrelated sections
* I like `requires` above `build-backend`.
